### PR TITLE
Quiet logs for normal operation

### DIFF
--- a/lib/Resque/Job.php
+++ b/lib/Resque/Job.php
@@ -252,6 +252,10 @@ class Resque_Job
 	 */
 	public function __toString()
 	{
+		return $this->toString(true);
+	}
+
+	public function toString($include_args = true) {
 		$name = array(
 			'Job{' . $this->queue .'}'
 		);
@@ -259,7 +263,7 @@ class Resque_Job
 			$name[] = 'ID: ' . $this->payload['id'];
 		}
 		$name[] = $this->payload['class'];
-		if(!empty($this->payload['args'])) {
+		if($include_args && !empty($this->payload['args'])) {
 			$name[] = json_encode($this->payload['args']);
 		}
 		return '(' . implode(' | ', $name) . ')';

--- a/lib/Resque/Worker.php
+++ b/lib/Resque/Worker.php
@@ -188,7 +188,8 @@ class Resque_Worker
 				continue;
 			}
 
-			$this->logger->log(Psr\Log\LogLevel::NOTICE, 'Starting work on {job}', array('job' => $job));
+			$this->logger->log(Psr\Log\LogLevel::INFO, 'Starting work on {job}', array('job' => $job->toString(false)));
+			$this->logger->log(Psr\Log\LogLevel::DEBUG, 'Full job details: {job}', array('job' => $job));
 			Resque_Event::trigger('beforeFork', $job);
 			$this->workingOn($job);
 
@@ -246,7 +247,7 @@ class Resque_Worker
 		}
 
 		$job->updateStatus(Resque_Job_Status::STATUS_COMPLETE);
-		$this->logger->log(Psr\Log\LogLevel::NOTICE, '{job} has finished', array('job' => $job));
+		$this->logger->log(Psr\Log\LogLevel::INFO, '{job} has finished.', array('job' => $job->toString(false)));
 	}
 
 	/**


### PR DESCRIPTION
The standard behavior is to log the full details of every job. In the
case of some events, this is a rather large JSON payload, making the
logs very unwieldy. This commit changes the log level from NOTICE to
INFO and adds a toString signature to get a summary of the job without
the full payload. The full details are logged at the DEBUG level.